### PR TITLE
Fix code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/vulnerable/sql.go
+++ b/vulnerable/sql.go
@@ -66,7 +66,7 @@ type Product struct {
 }
 
 func GetProducts(ctx context.Context, db *sql.DB, category string) ([]Product, error) {
-	rows, err := db.QueryContext(ctx, "SELECT * FROM product WHERE category='"+category+"'")
+	rows, err := db.QueryContext(ctx, "SELECT * FROM product WHERE category=?", category)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Go-2/security/code-scanning/4](https://github.com/Brook-5686/Go-2/security/code-scanning/4)

To fix the SQL injection vulnerability, we should use parameterized queries or prepared statements instead of directly concatenating user input into the SQL query. This approach ensures that user input is treated as data and not executable code.

In the `GetProducts` function, we will modify the SQL query to use a placeholder for the `category` parameter and pass the user-provided value as an argument to the `db.QueryContext` method. This change will prevent SQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
