### PR TITLE
Fix code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/template/Karma Shop-doc/syntax-highlighter/scripts/shBrushPython.js
+++ b/template/Karma Shop-doc/syntax-highlighter/scripts/shBrushPython.js
@@ -43,7 +43,7 @@
 				{ regex: /^\s*@\w+/gm, 										css: 'decorator' },
 				{ regex: /(['\"]{3})([^\1])*?\1/gm, 						css: 'comments' },
 				{ regex: /"(?!")(?:\.|\\\"|[^\""\n])*"/gm, 					css: 'string' },
-				{ regex: /'(?!')(?:\.|(\\\')|[^\''\n])*'/gm, 				css: 'string' },
+				{ regex: /'(?!')(?:\\'|[^'\n])*'/gm, 						css: 'string' },
 				{ regex: /\+|\-|\*|\/|\%|=|==/gm, 							css: 'keyword' },
 				{ regex: /\b\d+\.?\w*/g, 									css: 'value' },
 				{ regex: new RegExp(this.getKeywords(funcs), 'gmi'),		css: 'functions' },


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Go-2/security/code-scanning/2](https://github.com/Brook-5686/Go-2/security/code-scanning/2)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we can replace the ambiguous sub-expression `(?:\.|(\\\')|[^\''\n])*` with a more precise pattern that avoids multiple ways of matching the same string.

The best way to fix this without changing existing functionality is to use a character class that excludes the single quote and newline characters, along with handling escaped single quotes separately. This can be achieved by using a non-capturing group that matches either an escaped single quote or any character except a single quote and newline.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
